### PR TITLE
Prevent invalid range offset

### DIFF
--- a/src/Str.php
+++ b/src/Str.php
@@ -1936,7 +1936,7 @@ class Str
         }
         $this->s = \str_replace('@', $replacement, $this->s);
         $quotedReplacement = \preg_quote($replacement, '/');
-        $pattern = "/[^a-zA-Z\d\s-_$quotedReplacement]/u";
+        $pattern = "/[^-_a-zA-Z\d\s$quotedReplacement]/u";
         $this->s = (string) \preg_replace($pattern, '', $this->s);
         $this->s = \strtolower($this->s);
         $this->s = (string) \preg_replace("/^['\s']+|['\s']+\$/", '', $this->s);


### PR DESCRIPTION
Errors seen:

```
Warning: preg_replace(): Compilation failed: invalid range in character class at offset 12 in vendor/str/str/src/Str.php on line 1940
```

Solution: always place `-` at the beginning or end of expressions to prevent PCRE from interpreting the character as a range.