### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ php:
   - 7.2
 
 install:
-  - composer install --no-interaction --dev
+  - composer install --no-interaction
 
 script:
   - mkdir -p ./build/logs
-  - php ./vendor/bin/phpunit -c phpunit.xml
+  - php ./vendor/bin/phpunit
 
 after_success:
   - travis_retry php ./vendor/bin/php-coveralls

--- a/composer.json
+++ b/composer.json
@@ -32,10 +32,11 @@
             "Str\\": "src/"
         }
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "require-dev": {
-        "phpbench/phpbench": "1.0.*@dev",
-        "phpunit/phpunit": "6.5.13",
+        "phpbench/phpbench": "^0.16",
+        "phpunit/phpunit": "^7.0",
         "danielstjules/stringy": "3.1",
         "php-coveralls/php-coveralls": "2.1.0",
         "ramsey/uuid": "^3.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,7 +12,7 @@
     </filter>
 
     <logging>
-        <log type="coverage-html" target="build/cov/html/" title="Str" charset="UTF-8" />
+        <log type="coverage-html" target="build/cov/html/"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
         <log type="coverage-text" target="php://stdout" />
     </logging>


### PR DESCRIPTION
# Changed log
- The `--dev` option is deprecated during `composer install` command.
The deprecated warning message is as follows:

```
You are using the deprecated option "dev". Dev packages are installed by default now.
```
- The `phpunit.xml` is located on repository root folder by default.
It's fine to remove `-c phpunit.xml` option during `PHPUnit` executing.
- The `PHPUnit 7.0+` version can support `php-7.1` version at least.
- 