### PR TITLE
fixing wrong array key type for PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-  - 7.1
   - 7.2
   - 7.3
   - 7.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: php
 php:
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4
+  - 8.0
 
 install:
   - composer install --no-interaction --dev

--- a/composer.json
+++ b/composer.json
@@ -34,11 +34,11 @@
     },
     "minimum-stability": "stable",
     "require-dev": {
-        "phpbench/phpbench": "1.0.*@dev",
-        "phpunit/phpunit": "6.5.13",
+        "phpbench/phpbench": "dev-master",
+        "phpunit/phpunit": "^9.5",
         "danielstjules/stringy": "3.1",
-        "php-coveralls/php-coveralls": "2.1.0",
-        "ramsey/uuid": "^3.0",
-        "phpdocumentor/reflection-docblock": "^4.3"
+        "php-coveralls/php-coveralls": "^2.4",
+        "ramsey/uuid": "^4.1",
+        "phpdocumentor/reflection-docblock": "^5.2"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0",
+        "php": ">=7.2.0",
         "ext-mbstring": "*",
         "ext-json": "*"
     },
@@ -35,7 +35,7 @@
     "minimum-stability": "stable",
     "require-dev": {
         "phpbench/phpbench": "dev-master",
-        "phpunit/phpunit": ">=7.0",
+        "phpunit/phpunit": "^8.5",
         "danielstjules/stringy": "3.1",
         "php-coveralls/php-coveralls": "^2.4",
         "ramsey/uuid": "^4.1",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "minimum-stability": "stable",
     "require-dev": {
         "phpbench/phpbench": "dev-master",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": ">=7.0",
         "danielstjules/stringy": "3.1",
         "php-coveralls/php-coveralls": "^2.4",
         "ramsey/uuid": "^4.1",

--- a/src/Str.php
+++ b/src/Str.php
@@ -1932,7 +1932,7 @@ class Str
             $this->s = \str_replace($languageSpecific[$language][0], $languageSpecific[$language][1], $this->s);
         }
         foreach (self::CHARS_ARRAY as $key => $value) {
-            $this->s = \str_replace($value, $key, $this->s);
+            $this->s = \str_replace($value, (string)$key, $this->s);
         }
         $this->s = \str_replace('@', $replacement, $this->s);
         $quotedReplacement = \preg_quote($replacement, '/');
@@ -1981,7 +1981,7 @@ class Str
             $this->s = \str_replace($languageSpecific[$language][0], $languageSpecific[$language][1], $this->s);
         }
         foreach (self::CHARS_ARRAY as $key => $value) {
-            $this->s = \str_replace($value, $key, $this->s);
+            $this->s = \str_replace($value, (string)$key, $this->s);
         }
         if ($removeUnsupported) {
             $this->s = (string) \preg_replace('/[^\x20-\x7E]/', '', $this->s);

--- a/tests/FS/StrFullTest.php
+++ b/tests/FS/StrFullTest.php
@@ -600,7 +600,7 @@ class StrFullTest extends TestCase
     public function testChars($expected, $str)
     {
         $s = new Str($str);
-        $this->assertInternalType('array', $expected);
+        $this->assertIsArray($expected);
         $this->assertEquals($expected, $s->chars());
     }
 

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -103,7 +103,7 @@ class StrTest extends TestCase
     {
         $s = new Str('Önnek İş');
         $this->assertEquals('Önnekİş', $s->stripWhitespace());
-        $this->assertEquals('önnekiş', $s->toLowerCase());
+        $this->assertEquals('önneki̇ş', $s->toLowerCase());
         $this->assertTrue($s->hasPrefix('ön'));
         $this->assertEquals('ö', $s->at(0));
 

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -103,8 +103,14 @@ class StrTest extends TestCase
     {
         $s = new Str('Önnek İş');
         $this->assertEquals('Önnekİş', $s->stripWhitespace());
-        $this->assertEquals('önneki̇ş', $s->toLowerCase());
-        $this->assertTrue($s->hasPrefix('ön'));
+
+        if (PHP_VERSION_ID >= 70300) {
+            $this->assertEquals('önneki̇ş', $s->toLowerCase());
+        } else {
+            $this->assertEquals('önnekiş', $s->toLowerCase());
+        }
+
+        $this->assertTrue($s->startsWith('ön'));
         $this->assertEquals('ö', $s->at(0));
 
         $s = new Str('hello world');


### PR DESCRIPTION
Fixing [TypeError] str_replace(): Argument #2 ($replace) must be of type array|string, int given 
on PHP 8